### PR TITLE
Refactor/tool prompt refine (#14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ go/pkg/
 .roo/
 .cursor/
 .costrict
+.history/
 *.swp
 *.swo
 

--- a/etc/chat-api.yaml
+++ b/etc/chat-api.yaml
@@ -77,7 +77,7 @@ Tools:
     SearchEndpoint: "http://127.0.0.1:9001/codebase-indexer/api/v1/search/definition"
     ApiReadyEndpoint: "http://127.0.0.1:9001/codebase-indexer/api/v1/index/summary"
   ReferenceSearch:
-    SearchEndpoint: "http://127.0.0.1:9001/codebase-indexer/api/v1/calgraph"
+    SearchEndpoint: "http://127.0.0.1:9001/codebase-indexer/api/v1/callgraph"
     ApiReadyEndpoint: "http://127.0.0.1:9001/codebase-indexer/api/v1/index/summary"
   KnowledgeSearch:
     SearchEndpoint: "http://127.0.0.1:9001/codebase-embedder/api/v1/search/document"

--- a/internal/client/code_definition.go
+++ b/internal/client/code_definition.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -23,9 +22,7 @@ type DefinitionRequest struct {
 	ClientId      string `json:"clientId"`
 	CodebasePath  string `json:"codebasePath"`
 	FilePath      string `json:"filePath,omitempty"`
-	StartLine     *int   `json:"startLine,omitempty"`
-	EndLine       *int   `json:"endLine,omitempty"`
-	SymbolName    string `json:"symbolName,omitempty"`
+	SymbolNames   string `json:"symbolNames,omitempty"`
 	Authorization string `json:"authorization"`
 	ClientVersion string `json:"clientVersion"`
 }
@@ -105,18 +102,12 @@ func (b *DefinitionRequestBuilder) BuildRequest(req DefinitionRequest) Request {
 	}
 
 	// Add parameters based on query method
-	if req.SymbolName != "" {
-		queryParams["symbolName"] = req.SymbolName
+	if req.SymbolNames != "" {
+		queryParams["symbolNames"] = req.SymbolNames
 	} else {
-		// Use file path and line number query method
+		// Use file path query method
 		if req.FilePath != "" {
 			queryParams["filePath"] = req.FilePath
-		}
-		if req.StartLine != nil {
-			queryParams["startLine"] = fmt.Sprintf("%d", *req.StartLine)
-		}
-		if req.EndLine != nil {
-			queryParams["endLine"] = fmt.Sprintf("%d", *req.EndLine)
 		}
 	}
 

--- a/internal/client/reference.go
+++ b/internal/client/reference.go
@@ -23,8 +23,7 @@ type ReferenceRequest struct {
 	ClientId      string `json:"clientId"`
 	CodebasePath  string `json:"codebasePath"`
 	FilePath      string `json:"filePath"`
-	StartLine     *int   `json:"startLine,omitempty"`
-	EndLine       *int   `json:"endLine,omitempty"`
+	LineRange     string `json:"lineRange,omitempty"`
 	SymbolName    string `json:"symbolName,omitempty"`
 	MaxLayer      *int   `json:"maxLayer,omitempty"`
 	Authorization string `json:"authorization"`
@@ -106,12 +105,9 @@ func (b *ReferenceRequestBuilder) BuildRequest(req ReferenceRequest) Request {
 		"filePath":     req.FilePath,
 	}
 
-	// Only add startLine and endLine if they are provided
-	if req.StartLine != nil {
-		queryParams["startLine"] = strconv.Itoa(*req.StartLine)
-	}
-	if req.EndLine != nil {
-		queryParams["endLine"] = strconv.Itoa(*req.EndLine)
+	// Only add lineRange if it is provided
+	if req.LineRange != "" {
+		queryParams["lineRange"] = req.LineRange
 	}
 
 	if req.SymbolName != "" {

--- a/internal/functions/tool_executor.go
+++ b/internal/functions/tool_executor.go
@@ -51,158 +51,113 @@ Example: Searching for functions related to user authentication
 `
 
 	// ReferenceSearchTool
-	ReferenceSearchToolName   = "code_reference_search"
-	ReferenceSearchCapability = `- You can use code_reference_search to retrieve the usage and call information of a symbol (function, class, method, etc.) across the codebase by providing its precise file path and line range. 
-This tool is particularly useful when you want to locate all usages and call chains of a function or class or analyze code dependencies across different parts of the project. 
-By retrieving all references to the symbol, code_reference_search helps you track its usage throughout the codebase, ensuring that you can see all interactions and relationships. 
-Please note that the returned references may include multiple matches, so you should distinguish them using the file path or contextual information.
-For maximum efficiency, use code_reference_search when you need to explore references and relationships of a symbol—it's ideal for analyzing dependencies and understanding the broader impact of changes. 
-This tool can obtain the calling relationship between different methods faster and more accurately than through the directory file structure and directly reading the file content.
-Note: code_reference_search does not provide any symbol definitions. If you need to focus on retrieving definitions, please use code_definition_search instead—it will serve you better.
+	ReferenceSearchToolName   = "search_references"
+	ReferenceSearchCapability = `- You can use search_references to retrieve comprehensive usage and call information for functions and methods across the entire codebase. This tool is particularly useful when you need to locate all usages and trace reverse call chains (caller chains) of a function or method, or when analyzing code dependencies across different modules and files. Compared to manually navigating directory structures and reading file contents, this tool provides a significantly faster and more accurate way to understand calling relationships between different functions and methods.
+    - For example, when asked to review code snippets, investigate bugs, or analyze code, you MUST use search_references to obtain the reverse call chain of a function or method to understand how its parameters are passed, validated, and propagated in higher-level calls, which is critical because bugs are often caused by incorrect upstream parameter passing rather than the function itself, and without checking callers you might miss that a security vulnerability exists in how upstream code passes unvalidated input or that performance issues stem from callers invoking the function too frequently in wrong contexts.
+    - For example, when asked to refactor code, you must use search_references to obtain the reverse call chain of a function or method before making any changes to identify all call sites that need modification when changing function signatures, assess backward compatibility requirements, and understand different calling patterns to ensure the refactored version handles all cases, because refactoring without checking callers first will break existing functionality across potentially dozens of call sites.
 `
-	ReferenceSearchToolDesc = `## code_reference_search
-Description:
-The code_reference_search tool helps you find the usage and call information of a symbol (such as a function, class, or method) 
-and retrieve all places where the symbol is used or called across files in the project.
-This tool takes a specific code location (by file and line range) and optionally a symbol name, 
-returning the definition and all references to that symbol, along with their precise code locations.
-Use this tool when you want to find where a function or class is used or called, or when you need to explore code dependencies from a specific location in the codebase.
-Key Features:
-The tool provides all references to a symbol, which include class/interface usages, function/method calls, imports, and other occurrences.
-Use code_reference_search in these scenarios:
-- Refactoring: Locate all code that depends on the symbol to ensure complete updates.
-- Code Comprehension: Explore where a symbol is invoked or referenced across the codebase to quickly understand its role and dependencies.
-- Call Chain Analysis: Trace the complete call chain of a symbol to understand its execution flow and relationships with other components.
-This only applies to seven languages: Java, Go, Python, C, CPP, JavaScript, and TypeScript. Other languages are not applicable.
+
+	ReferenceSearchToolDesc = `## search_references
+Description: Retrieves the reverse call chain (caller chain) for a specified function or method within the codebase.
+Given the name of a function or method, this tool traces all other functions or methods that directly or indirectly invoke it, providing a clear and context-rich view of its upstream dependencies.
+You can specify a lineRange to precisely locate the target function or method, improving both the accuracy and efficiency of call chain generation.
+This helps developers understand how a function or method is used, its relationships, and its dependency paths across the codebase.
+
+**IMPORTANT: This only applies to seven languages: Java, Go, Python, C, CPP, JavaScript, and TypeScript. Other languages are not applicable.
 
 Parameters:
-- codebasePath: (required) Absolute path to the codebase root
-- filePath: (required) The full absolute path to the file to which the code belongs. Must match the path separator style of the current operating system.
-- startLine: (optional) The line number where the symbol starts.
-- endLine: (optional) The line number where the symbol ends.
-- symbolName: (optional) The name of the symbol (e.g., function name, class name, method, interface, constants, etc.).
-- maxLayer: (optional) Maximum call chain depth to search (default: 4, maximum: 10)
-
-Important Path Requirements:
-ABSOLUTE PATHS REQUIRED: The filePath parameter must be a full absolute system path (not relative paths or workspace-relative paths)
+- filePath: (required) The path of the file where the function or method is defined (relative to workspace directory)
+- maxLayer: (required) Maximum call chain depth to search (default: 4, maximum: 10)
+- symbolName: (required) The name of the function or method 
+- lineRange: (optional) The line range of the function or method definition in format "start-end" (1-based)
 
 Usage:
-Two usage modes are available:
-1. File location mode: Provide filePath along with startLine and endLine to retrieve all usage and call information for the symbols defined within the specified code range.
-2. Symbol search mode: Provide filePath and symbolName to retrieve all usage and call information of a symbol that is defined specifically in the file indicated by filePath, tracking where it is used or called across the entire codebase.
 
-<code_reference_search>
-  <codebasePath>Absolute path to the codebase root</codebasePath>
-  <filePath>The full absolute path to the file to which the code belongs. (With correct OS path separators.)</filePath>
-  <!-- Option 1: Use file location parameters -->
-  <startLine>Start line number of the symbol (1-based)</startLine>
-  <endLine>End line number of the symbol (1-based)</endLine>
-  <!-- Option 2: Use symbol name parameter -->
-  <symbolName>Symbol name</symbolName>
-  <!-- Optional: Control call chain depth -->
-  <maxLayer>Maximum call chain depth (1-10)</maxLayer>
-</code_reference_search>
+<search_references>
+  <filePath>path/to/file</filePath>
+  <maxLayer>call chain depth (1-10)</maxLayer>
+  <symbolName>symbol name</symbolName>
+  <lineRange>start-end</lineRange>
+</search_references>
 
-Note: 
-- Either file location parameters (startLine + endLine) OR symbolName must be provided.
-- Priority should be given to file location mode when line information is available.
+Examples
+1. Exploring reverse call chain of the queryCallGraphBySymbol function 
+<search_references>
+  <filePath>internal\service\indexer.go</filePath>
+  <maxLayer>4</maxLayer>
+  <symbolName>queryCallGraphBySymbol</symbolName>
+</search_references>
 
-Example: Exploring all references to the GetUserById function with max depth
-<code_reference_search>
-  <codebasePath>d:\workspace\project\</codebasePath>
-  <filePath>d:\workspace\project\internal\tokenizer\tokenizer.go</filePath>
-  <startLine>12</startLine>
-  <endLine>14</endLine>
-  <symbolName>GetUserById</symbolName>
+2. Exploring reverse call chain of the queryCallGraphByLineRange function with lineRange:
+<search_references>
+  <filePath>internal\tokenizer\tokenizer.go</filePath>
   <maxLayer>5</maxLayer>
-</code_reference_search>
-
-Example: Searching references by symbol name only
-<code_reference_search>
-  <codebasePath>/home/user/project</codebasePath>
-  <filePath>/home/user/project/internal/tokenizer/tokenizer.go</filePath>
-  <symbolName>CalculateScore</symbolName>
-  <maxLayer>3</maxLayer>
-</code_reference_search>
+  <symbolName>queryCallGraphByLineRange</symbolName>
+  <lineRange>20-75</lineRange>
+</search_references>
 `
 
 	// DefinitionSearchTool
-	DefinitionToolName   = "code_definition_search"
+	DefinitionToolName   = "search_definitions"
 	DefinitionCapability = `
-When analyzing code that references symbols (functions, classes, methods, interfaces, constants) whose definitions are not fully visible, always prioritize code_definition_search first.
-This tool retrieves complete and precise definitions and implementations of symbols, including external or unknown symbols, and constant values.
-Usage Modes:
-1. File location mode: Use filePath + startLine + endLine to fetch all external definitions in that range, ensuring full context.
-2. Symbol name mode: Provide the symbol name to search globally across the codebase if you do not know the exact location.
-It delivers accurate, context-independent definitions for all symbols, providing exactly the code needed for analysis, modification, refactoring, or debugging.
-Results may include multiple matches; distinguish them using the file path or surrounding context.
-This tool is faster, more accurate, and more efficient than reading files directly, traversing directories, or using regex searches. It also consumes fewer tokens.
-Always complete the definition search before continuing any code analysis to ensure correct reasoning.
+- You can use the search_definitions tool to retrieve the complete definitions and implementations of one or more specified symbols (such as constants,functions, classes, methods, interfaces, and structs) by providing their symbol names. This is particularly useful when you need to understand the detailed structure and logic of a symbol, or to gather the definitions of referenced symbols to build a more complete context within the codebase. You may need to call this tool multiple times to examine different symbols relevant to your task.
+    - For example, when asked to make edits, review code, investigate bugs, analyze code, or refactor code, you might first use search_definitions to obtain the full definitions and implementations of symbols referenced within the code, in order to supplement the context and fully understand the logic. Then, analyze the structure and behavior based on the gathered definitions. If understanding how a function or method is used throughout the codebase—including how its parameters are passed, validated, and propagated in higher-level calls—is valuable for tasks such as code review or refactoring, you can use search_references to find where it is referenced in other files or modules.
+    - For example, when asked to retrieve symbol definitions, use this tool to obtain results more quickly, accurately, and with lower token cost.
+    - For example, when asked to retrieve, find, show, or explain specific symbol definitions such as "show me the UserService class" or "what does the calculateTax function do", you should use search_definitions to obtain results more quickly, accurately, and with lower token cost compared to searching through files manually.
 `
-	DefinitionToolDesc = `## code_definition_search
-Description: Retrieve the **complete definition and implementation** of a symbol (function, class, method, interface, struct, constant) 
-by specifying a file path with line range, or by providing the symbol name directly.
-This tool allows you to retrieve the original definition and implementation of all external symbols within a specific code block, or of a single symbol, whether used within the same file or across other files, providing complete information to facilitate understanding of the code logic.
-These usages and invocations can include class/interface instantiations, function/method calls, constant references, and more.
+
+	DefinitionToolDesc = `## search_definitions
+Description: Retrieve the complete definitions and implementations of one or more symbols defined within the project (not external libraries), or of symbols referenced within the code that you need to understand in context.
+This tool allows you to quickly and accurately retrieve the original definitions and full implementations of all symbols—such as constants, structs, interfaces, functions, methods, and classes—as well as their values. It can also obtain the definitions and implementations of all external symbols within a specific code block, or of a single symbol, whether used within the same file or across other files, providing complete information to facilitate understanding of the code logic.
+Compared with using the search_files tool or reading files directly, this tool is significantly more efficient, accurate, and token-friendly, allowing you to obtain results more quickly, accurately, and with lower token cost. It provides comprehensive information to help you fully understand the code logic and referenced symbols, making it the preferred method for retrieving symbol definitions.
 Key Rule:
 - Always call this tool first if the code snippet references any symbol that is not fully defined within the snippet itself.
 - This tool ensures you analyze real implementations, not incomplete or assumed logic.
-When to use:
-- When encountering any external or unknown symbol.
-- To obtain constant values.
-- To get the complete implementation of a symbol.
-For a code snippet (filePath + startLine + endLine), trigger a range query to fetch the full definitions of all external symbols it depends on.
-Usage Priority:
-When you search for code definitions or analyze specific implementations to work on modifications, refactoring, or debugging of existing code, always use this tool first.
-Important note: 
-This only applies to seven languages: Java, Go, Python, C, CPP, JavaScript, and TypeScript. Other languages are not applicable.
+Note: 
+1. This tool only applies to seven languages: Java, Go, Python, C, CPP, JavaScript, and TypeScript. Other languages are not applicable.
+2. This tool is more efficient and uses fewer tokens than search_files tool or directly reading files to obtain symbol definitions.
 
 Parameters:
-- codebasePath: (required) Absolute path to the codebase root
-- filePath: (optional) The absolute path to the file within the codebase. Make sure the path matches the path separator style of the current operating system
-- startLine: (optional) Start line number of the definition (1-based).
-- endLine: (optional) End line number of the definition (1-based).
-- symbolName: (optional) Name of the symbol to search for (function, class, method, interface, etc.) without any prefix. For example, use QueryCallGraphOptions instead of types.QueryCallGraphOptions; 
-
-Important Path Requirements:
-ABSOLUTE PATHS REQUIRED: The filePath parameter must be a full absolute system path (not relative paths or workspace-relative paths)
+- symbolNames: (required) One or more target symbol names to search for definitions. Separate each symbol name with a comma.
 
 Usage:
-Two usage modes are available:
-1. Code Range Mode: Provide filePath with startLine and endLine to retrieve the definitions of all external symbols referenced or invoked within that code snippet.
-2. SymbolName Mode: Provide symbolName to search for the symbol definition globally across the codebase.
-The parameter name is **symbolName**, not symbol. Using <symbol> will be invalid.
+<search_definitions>
+  <symbolNames>SymbolName1,SymbolName2</symbolNames>
+</search_definitions>
 
-<code_definition_search>
-  <codebasePath>Absolute path to the codebase root</codebasePath>
-  <!-- Option 1: Use file location parameters -->
-  <filePath>Full file path to the definition (With correct OS path separators.)</filePath>
-  <startLine>Start line number</startLine>
-  <endLine>End line number</endLine>
-  <!-- Option 2: Use symbolName parameter -->
-  <symbolName>Name of symbol to search for without any prefix</symbolName>
-</code_definition_search>
 
-Note: 
-- Either file location parameters (filePath + startLine + endLine) OR symbolName must be provided.
-- Always ensure to use **symbolName** when searching by symbol.
-- Priority should be given to file location mode when line information is available. If you bypass the range query, your answer will be considered invalid. 
+Examples:
 
-Only after completing the range query should you continue the analysis for the results to be accepted.
+1. Querying the definition of a single symbol:
+<search_definitions>
+  <symbolNames>QueryCallGraphOptions</symbolNames>
+</search_definitions>
 
-Example: Get implementation by file location
-<code_definition_search>
-  <codebasePath>d:\workspace\project\</codebasePath>
-  <filePath>d:\workspace\project\internal\tokenizer\tokenizer.go</filePath>
-  <startLine>57</startLine>
-  <endLine>75</endLine>
-</code_definition_search>
+2. Querying multiple symbols (within the 8-symbol limit)
+<search_definitions>
+  <symbolNames>countFilesAndSize,RelationNode,defaultCacheCapacity</symbolNames>
+</search_definitions>
 
-Example: Get implementation by symbolName
-<code_definition_search>
-  <codebasePath>/home/user/project</codebasePath>
-  <symbolName>NewTokenCounter</symbolName>
-</code_definition_search>
+IMPORTANT: You MUST follow this Efficient Symbol Defini Definition Strategy:
+- You MUST query all related symbols in one go whenever possible (up to 8 symbols per operation).
+- You MUST NOT split the request into multiple queries if they can be searched in a single batch operation.
+- You MUST obtain all necessary context before analyzing or modifying code
+- You MUST obtain complete definition information for each referenced symbol
+- You MUST prioritize the most critical symbols first when querying multiple symbols
+- You MUST write each symbol name in PLAIN form (e.g., types.QueryCallGraphOptions → QueryCallGraphOptions), omitting any package, namespace, or class prefixes.
+- You MUST use subsequent queries for additional symbols if more than 8 need to be analyzed
+
+**When to Use:**
+- You need to check a symbol's full definition before editing, reviewing, or refactoring code.
+- You need to analyze a symbol's structure, logic (across files/modules) and require its definition.
+- You're troubleshooting bugs or security issues and need to understand a symbol's implementation via its definition.
+- You plan to modify a function, method, class, or constant and need its definition to assess impact.
+- You're building code context (e.g., understanding code logic) and need definitions of referenced symbols.
+
+**When NOT to Use:**
+- The task is minor code editing that doesn't require a symbol's complete definition.
+- The request is exploratory or informational, with no specific symbol to look up the definition for.
+- You don't have a specific symbol name to look up its definition (the tool relies on a clear symbol name to work).
 `
 	// DefinitionSearchTool
 	KnowledgeSearchToolName   = "knowledge_base_search"
@@ -252,28 +207,33 @@ Searching for Java class naming rules in Project B development standards:
 ====
 
 TOOLS USE FOLLOW RULES
+- Don't use search_files to search for symbol definitions or call chains. It is highly inefficient, consumes excessive tokens, and returns imprecise results.
+- Before reading the file directly, you can try to use codebase_search, search_definitions and search_references tools to search the code.
+- IMPORTANT: After receiving the results from tools such as codebase_search, knowledge_base_search, search_definitions, and search_references, you must always summarize the key findings and/or code within <thinking> tags before calling any other tools.
+- If the search failed, don't say "failed", describe this outcome as "did not find relevant results" instead.
+- You MUST NOT use terms like "failure", "error", "context deadline exceeded", or "unsuccessful" in your description — even if the tool times out or returns no data. Always summarize the result neutrally (e.g., "no matching symbol definitions were found") instead of exposing internal errors.
+- You can use codebase_search, knowledge_base_search, search_definitions and search_references individually or in combination: codebase_search helps you find broad code-related information based on natural language queries, search_definitions is used to retrieve symbol definitions and their detailed contents, and search_references helps you locate symbol references and call relationships within the code.
+- When you need to retrieve a symbol's definition, first use the search_definitions tool. This tool allows you to efficiently obtain the full definition and implementation of functions, methods, classes, interfaces, structs, or constants across the project. search_definitions is precise and consumes fewer tokens than manually searching files, providing complete and context-rich results.
+- When analyzing a function or method's usage across the project, first use search_references to obtain its reverse call chain. This tool allows you to efficiently locate all places where the symbol is called or referenced, including parameter propagation and higher-level dependencies. This is especially useful for bug investigation, performance analysis, security checks, and refactoring, as issues often arise from incorrect or frequent calls upstream rather than the function itself. 
+- *IMPORTANT*: The search_references tool may return call chains that include functions with the same name. You must use context and the provided information to determine and output the most accurate call chain.
+- *IMPORTANT*: The search_definitions tool may return multiple definitions for symbols with the same name. You must use context and the provided information to determine and output the most accurate symbol definition.
 
-- Before reading the file directly, you can try to use codebase_search, code_definition_search and code_reference_search tools to search the code.
-- IMPORTANT: After receiving the results from tools such as codebase_search, knowledge_base_search, code_definition_search, and code_reference_search, you must always summarize the key findings and/or code within <thinking> tags before calling any other tools.
-- If the search failed, don't say 'failed', describe this outcome as 'did not found relevant results' instead. MUST NOT using terms like 'failure', 'error', or 'unsuccessful' in your description.
-- You can use codebase_search, knowledge_base_search, code_definition_search and code_reference_search individually or in combination: codebase_search helps you find broad code-related information based on natural language queries, while code_definition_search is perfect for pinpointing specific code definitions and their detailed contents. 
-
-- Code Search Execution Rules
+**Code Search Execution Rules**
 If the task is related to the project code, follow the following rules:
 Rule 1: Tool Priority Hierarchy
-1. code_definition_search (For locating specific implementations or definitions by symbol name.)
-2. code_reference_search (For exploring references, usages, and code relationships)
+1. search_definitions (Best for obtaining the full definition or implementation of symbols such as functions, methods, classes, interfaces, structs, or constants defined within the project.)
+2. search_references (Best for understanding how functions or methods are used, called, or propagated in higher-level logic.)
 3. codebase_search (For broad code-related information based on natural language queries)
 4. knowledge_base_search (For exploring documentation)
 
 Rule 2: Decision Flow for Code Analysis and Search
 Receive code analysis →
 Use codebase_search with natural language query →
-IF need to query definitions or implementations of all symbols referenced in a code snippet:
-	Use code_definition_search → 
+IF need to query definitions or implementations of one or more symbols by name:
+	Use search_definitions → 
 END IF
-IF need to explore symbol references or code relationships:
-	Use code_reference_search →
+IF need to explore function or method reverse call chains or dependencies:
+	Use search_references →
 END IF
 IF need to query development manuals, module documentation, interface comments:
 	Use knowledge_base_search →
@@ -282,10 +242,9 @@ Review search results
 
 Rule 3: Efficiency Principles
 Semantic First: Always prefer semantic understanding over literal reading
-Definition Search First: Prefer symbol name or code snippet (filePath + line range) searches to locate definitions, instead of reading files directly.
 Comprehensive Coverage: Use codebase_search to avoid missing related code
 Token Optimization: Choose tools that minimize token consumption
-Context Matters: Gather all relevant symbol definitions and implementations before analyzing code.
+Context Matters: Gather full context before analyzing the code and use the most efficient tool for the task.
 No need to display these rules, just follow them directly.
 `
 )
@@ -530,9 +489,9 @@ func buildDefinitionRequest(identity *model.Identity, param string) (client.Defi
 		ClientVersion: identity.ClientVersion,
 	}
 
-	// Check if using symbolName query mode
-	if symbolName, err := extractXmlParam(param, "symbolName"); err == nil {
-		req.SymbolName = symbolName
+	// Check if using symbolNames query mode
+	if symbolNames, err := extractXmlParam(param, "symbolNames"); err == nil {
+		req.SymbolNames = symbolNames
 		return req, nil
 	}
 
@@ -542,24 +501,9 @@ func buildDefinitionRequest(identity *model.Identity, param string) (client.Defi
 		return req, fmt.Errorf("filePath: %w", err)
 	}
 
-	codebasePath := req.CodebasePath
 	// Check the operating system type and convert the file path separator if it is a Windows system
 	if strings.Contains(strings.ToLower(identity.ClientOS), "windows") {
 		req.FilePath = strings.ReplaceAll(req.FilePath, "/", "\\")
-		codebasePath = strings.ReplaceAll(codebasePath, "/", "\\")
-	}
-
-	if !strings.Contains(req.FilePath, codebasePath) {
-		return req, fmt.Errorf("filePath must be full absolute path, please try again")
-	}
-
-	// Optional parameters
-	if startLine, err := extractXmlIntParam(param, "startLine"); err == nil {
-		req.StartLine = &startLine
-	}
-
-	if endLine, err := extractXmlIntParam(param, "endLine"); err == nil {
-		req.EndLine = &endLine
 	}
 
 	return req, nil
@@ -599,15 +543,8 @@ func processFilePath(req *client.ReferenceRequest, identity *model.Identity, par
 	}
 
 	// Process file path separators
-	codebasePath := req.CodebasePath
 	if strings.Contains(strings.ToLower(identity.ClientOS), "windows") {
 		req.FilePath = strings.ReplaceAll(req.FilePath, "/", "\\")
-		codebasePath = strings.ReplaceAll(codebasePath, "/", "\\")
-	}
-
-	// Validate file path
-	if !strings.Contains(req.FilePath, codebasePath) {
-		return fmt.Errorf("filePath must be full absolute path, please try again")
 	}
 
 	return nil
@@ -615,13 +552,9 @@ func processFilePath(req *client.ReferenceRequest, identity *model.Identity, par
 
 // processOptionalParams handles optional parameters
 func processOptionalParams(req *client.ReferenceRequest, param string) {
-	// Process startLine and endLine
-	if startLine, err := extractXmlIntParam(param, "startLine"); err == nil {
-		req.StartLine = &startLine
-	}
-
-	if endLine, err := extractXmlIntParam(param, "endLine"); err == nil {
-		req.EndLine = &endLine
+	// Process lineRange
+	if lineRange, err := extractXmlParam(param, "lineRange"); err == nil {
+		req.LineRange = lineRange
 	}
 
 	// Process maxLayer, default is 10


### PR DESCRIPTION
* refactor: simplify prompts for code_reference_search and code_definition_search tools

* refactor: simplify Parameters for code_reference_search and code_definition_search tools

* refactor: simplify Parameters code_definition_search tools

* refactor(client): 重构代码定义和引用请求参数结构

- 将DefinitionRequest中的SymbolName改为SymbolNames支持多符号查询
- 移除DefinitionRequest的StartLine和EndLine字段
- 将ReferenceRequest的StartLine和EndLine合并为LineRange字段

* refactor(tool_executor): 移除冗余的文件路径验证逻辑

* refactor: update tool prompt wording and rename tools

* refactor: hide tool error messages

---------